### PR TITLE
Add simple video transcription tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Video Transcriptor
+
+This project provides a simple command line tool to convert an MPEG-4 video into a text transcript formatted in Obsidian‑friendly markdown.
+
+## Requirements
+
+* Python 3.11+
+* [FFmpeg](https://ffmpeg.org/) installed and available on the system path
+* Python dependencies from `requirements.txt`
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+./transcribe.py path/to/video.mp4
+```
+
+The command will create `video.md` beside the input file. Use the `-o` option to specify another output file and `-m` to choose a Whisper model size.
+
+The resulting markdown contains timestamped bullet points that link to the corresponding time in the video, making it convenient to use with Obsidian.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openai-whisper

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,12 @@
+from videotranscriptor.transcribe import segments_to_markdown
+
+def test_segments_to_markdown():
+    segments = [
+        {"start": 0.0, "text": "Hello world"},
+        {"start": 5.2, "text": "Next line"},
+    ]
+    expected = (
+        "- [00:00:00](#t=00:00:00) Hello world\n"
+        "- [00:00:05](#t=00:00:05) Next line\n"
+    )
+    assert segments_to_markdown(segments) == expected

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Command-line interface for video transcription."""
+
+import argparse
+from pathlib import Path
+from videotranscriptor.transcribe import transcribe_video, segments_to_markdown
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Transcribe an MP4 file to Obsidian markdown")
+    parser.add_argument("video", help="Path to the MP4 video file")
+    parser.add_argument("-m", "--model", default="base", help="Whisper model size")
+    parser.add_argument("-o", "--output", help="Output markdown file")
+    args = parser.parse_args()
+
+    segments = transcribe_video(args.video, model=args.model)
+    markdown = segments_to_markdown(segments)
+
+    output_path = Path(args.output) if args.output else Path(args.video).with_suffix(".md")
+    with open(output_path, "w") as f:
+        f.write(markdown)
+
+    print(f"Transcript written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/videotranscriptor/transcribe.py
+++ b/videotranscriptor/transcribe.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from typing import List, Dict
+
+try:
+    import whisper
+except ImportError as e:
+    whisper = None
+
+
+def transcribe_video(video_path: str, model: str = "base") -> List[Dict]:
+    """Transcribe a video file using OpenAI Whisper."""
+    if whisper is None:
+        raise ImportError("whisper package is required for transcription")
+    model = whisper.load_model(model)
+    result = model.transcribe(video_path)
+    return result.get("segments", [])
+
+
+def format_timestamp(seconds: float) -> str:
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def segments_to_markdown(segments: List[Dict]) -> str:
+    """Convert transcription segments to Obsidian-friendly markdown."""
+    lines = []
+    for seg in segments:
+        timestamp = format_timestamp(seg.get("start", 0))
+        text = seg.get("text", "").strip()
+        lines.append(f"- [{timestamp}](#t={timestamp}) {text}")
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add CLI to convert mp4 videos to markdown transcripts
- implement helper functions for timestamp formatting
- document usage in README
- add basic formatting unit test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad35be67c832eb3639b90cefb6e8a